### PR TITLE
fix reference to mcplabels

### DIFF
--- a/src/main/plugin/iso19139.anzlic/layout/dispatcher.xsl
+++ b/src/main/plugin/iso19139.anzlic/layout/dispatcher.xsl
@@ -31,7 +31,7 @@
     <xsl:apply-templates mode="mode-iso19139" select="$base">
       <xsl:with-param name="overrideLabel" select="$overrideLabel"/>
       <xsl:with-param name="schema" select="$schema"/>
-      <xsl:with-param name="labels" select="$iso19139.mcplabels"/>
+      <xsl:with-param name="labels" select="$iso19139.anzliclabels"/>
     </xsl:apply-templates>
   </xsl:template>
 


### PR DESCRIPTION
Copy & paste error had a reference to mcplabels instead of anzlic labels, this prevented editor opening
